### PR TITLE
Keywordize responses from calls in browser

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/cljs-ipfs-http-client "1.0.5-SNAPSHOT"
+(defproject district0x/cljs-ipfs-http-client "1.0.6-SNAPSHOT"
   :description "library for calling ipfs HTTP API"
   :url "https://github.com/district0x/cljs-ipfs-http-client"
   :license {:name "Eclipse Public License"

--- a/src/cljs_ipfs_api/utils.cljs
+++ b/src/cljs_ipfs_api/utils.cljs
@@ -71,7 +71,7 @@
                                   (when-not [empty? args]
                                     {"arg" (clojure.string/join " " args)}))
                                 opts))
-      (merge {:handler (fn [response] (callback nil response))
+      (merge {:handler (fn [response] (callback nil (js->cljkk (.parse js/JSON response))))
               :error-handler (fn [err] (callback err nil))
               :response-format (ajax/raw-response-format)}
              (when-let [b (first (filter is-blob? args))]


### PR DESCRIPTION
Changes the behaviour in browser to match that in node.js:
  - when the response comes, it'll be a map with keywords as keys

Before:
```clj
(add-edn! {:zombies "Are here"})
{"Name":"QmSHmtLuCkSYZUbmFqLXBtt9MbvL25Uwx9PC1TbBWiGjZ1","Hash":"QmSHmtLuCkSYZUbmFqLXBtt9MbvL25Uwx9PC1TbBWiGjZ1","Size":"88"}
```

After:
```clj
(add-edn! {:zombies "Are here"})
{:Name "QmSHmtLuCkSYZUbmFqLXBtt9MbvL25Uwx9PC1TbBWiGjZ1", :Hash "QmSHmtLuCkSYZUbmFqLXBtt9MbvL25Uwx9PC1TbBWiGjZ1", :Size "88"}
```